### PR TITLE
Backend events select

### DIFF
--- a/api/src/JMP/Controllers/EventsController.php
+++ b/api/src/JMP/Controllers/EventsController.php
@@ -47,6 +47,10 @@ class EventsController
         /** @var User $user */
         $user = new User($optional->getData());
 
+        if ((bool)$user->isAdmin !== true && isset($request->getQueryParams()['all']) === true) {
+            return $response->withStatus(401);
+        }
+
         // if limit and offset are not set do not use pagination
         if (empty($request->getQueryParam('limit')) && empty($request->getQueryParam('offset'))) {
             $arguments = $this->fetchArgs($request->getQueryParams(), $user->isAdmin);

--- a/api/src/JMP/Controllers/EventsController.php
+++ b/api/src/JMP/Controllers/EventsController.php
@@ -54,7 +54,7 @@ class EventsController
         // if limit and offset are not set do not use pagination
         if (empty($request->getQueryParam('limit')) && empty($request->getQueryParam('offset'))) {
             $arguments = $this->fetchArgs($request->getQueryParams(), $user->isAdmin);
-            $events = Converter::convertArray($this->eventService->getEventsByGroupAndEventType($arguments['group'], $arguments['eventType'], $arguments['all'], $user));
+            $events = Converter::convertArray($this->eventService->getEventsByGroupAndEventType($arguments['group'], $arguments['eventType'], $arguments['all'], $arguments['elapsed'], $user));
             return $response->withJson($events);
         } else {
             $arguments = $this->fetchArgsWithPagination($request->getQueryParams(), $user->isAdmin);
@@ -62,10 +62,10 @@ class EventsController
             if (is_null($arguments['limit'])) {
                 // no limit, just use offset
                 $events = Converter::convertArray($this->eventService->getEventByGroupAndEventWithOffset($arguments['group'],
-                    $arguments['eventType'], $arguments['all'], $user, $arguments['offset']));
+                    $arguments['eventType'], $arguments['all'], $arguments['elapsed'], $user, $arguments['offset']));
             } else {
                 $events = Converter::convertArray($this->eventService->getEventsByGroupAndEventTypeWithPagination($arguments['group'],
-                    $arguments['eventType'], $arguments['limit'], $arguments['all'], $user, $arguments['offset']));
+                    $arguments['eventType'], $arguments['limit'], $arguments['all'], $arguments['elapsed'], $user, $arguments['offset']));
             }
 
             return $response->withJson($events);
@@ -104,7 +104,8 @@ class EventsController
             'eventType' => isset($params['eventType']) ? (int)$params['eventType'] : null,
             'limit' => isset($params['limit']) ? (int)$params['limit'] : null,
             'offset' => (int)$params['offset'],
-            'all' => isset($params['all']) && $isAdmin === true ? (bool)$params['all'] : false
+            'all' => isset($params['all']) && $isAdmin === true ? (bool)$params['all'] : false,
+            'elapsed' => isset($params['elapsed']) ? (bool)$params['elapsed'] : false
         ];
     }
 
@@ -118,7 +119,8 @@ class EventsController
         return [
             'group' => isset($params['group']) ? (int)$params['group'] : null,
             'eventType' => isset($params['eventType']) ? (int)$params['eventType'] : null,
-            'all' => isset($params['all']) && $isAdmin === true ? (bool)$params['all'] : false
+            'all' => isset($params['all']) && $isAdmin === true ? (bool)$params['all'] : false,
+            'elapsed' => isset($params['elapsed']) ? (bool)$params['elapsed'] : false
         ];
     }
 

--- a/api/src/JMP/Controllers/EventsController.php
+++ b/api/src/JMP/Controllers/EventsController.php
@@ -48,7 +48,7 @@ class EventsController
         $user = new User($optional->getData());
 
         if ((bool)$user->isAdmin !== true && isset($request->getQueryParams()['all']) === true) {
-            return $response->withStatus(401);
+            return $response->withStatus(403);
         }
 
         // if limit and offset are not set do not use pagination

--- a/api/src/JMP/Controllers/EventsController.php
+++ b/api/src/JMP/Controllers/EventsController.php
@@ -49,19 +49,19 @@ class EventsController
 
         // if limit and offset are not set do not use pagination
         if (empty($request->getQueryParam('limit')) && empty($request->getQueryParam('offset'))) {
-            $arguments = $this->fetchArgs($request->getQueryParams());
-            $events = Converter::convertArray($this->eventService->getEventsByGroupAndEventType($arguments['group'], $arguments['eventType'], $user));
+            $arguments = $this->fetchArgs($request->getQueryParams(), $user->isAdmin);
+            $events = Converter::convertArray($this->eventService->getEventsByGroupAndEventType($arguments['group'], $arguments['eventType'], $arguments['all'], $user));
             return $response->withJson($events);
         } else {
-            $arguments = $this->fetchArgsWithPagination($request->getQueryParams());
+            $arguments = $this->fetchArgsWithPagination($request->getQueryParams(), $user->isAdmin);
 
             if (is_null($arguments['limit'])) {
                 // no limit, just use offset
                 $events = Converter::convertArray($this->eventService->getEventByGroupAndEventWithOffset($arguments['group'],
-                    $arguments['eventType'], $user, $arguments['offset']));
+                    $arguments['eventType'], $arguments['all'], $user, $arguments['offset']));
             } else {
                 $events = Converter::convertArray($this->eventService->getEventsByGroupAndEventTypeWithPagination($arguments['group'],
-                    $arguments['eventType'], $arguments['limit'], $user, $arguments['offset']));
+                    $arguments['eventType'], $arguments['limit'], $arguments['all'], $user, $arguments['offset']));
             }
 
             return $response->withJson($events);
@@ -90,27 +90,31 @@ class EventsController
 
     /**
      * @param array $params
+     * @param bool $isAdmin
      * @return array
      */
-    private function fetchArgsWithPagination(array $params): array
+    private function fetchArgsWithPagination(array $params, bool $isAdmin): array
     {
         return [
             'group' => isset($params['group']) ? (int)$params['group'] : null,
             'eventType' => isset($params['eventType']) ? (int)$params['eventType'] : null,
             'limit' => isset($params['limit']) ? (int)$params['limit'] : null,
-            'offset' => (int)$params['offset']
+            'offset' => (int)$params['offset'],
+            'all' => isset($params['all']) && $isAdmin === true ? (bool)$params['all'] : false
         ];
     }
 
     /**
      * @param array $params
+     * @param bool $isAdmin
      * @return array
      */
-    private function fetchArgs(array $params): array
+    private function fetchArgs(array $params, bool $isAdmin): array
     {
         return [
             'group' => isset($params['group']) ? (int)$params['group'] : null,
             'eventType' => isset($params['eventType']) ? (int)$params['eventType'] : null,
+            'all' => isset($params['all']) && $isAdmin === true ? (bool)$params['all'] : false
         ];
     }
 

--- a/api/src/dependencies.php
+++ b/api/src/dependencies.php
@@ -7,7 +7,7 @@ use Monolog\Processor\WebProcessor;
 use Tuupola\Middleware\JwtAuthentication;
 
 /**
- * @var \Psr\Container\ContainerInterface
+ * @var $container \Psr\Container\ContainerInterface
  */
 $container = $app->getContainer();
 

--- a/api/src/routes.php
+++ b/api/src/routes.php
@@ -10,10 +10,14 @@ use JMP\Middleware\AuthenticationMiddleware;
 use JMP\Middleware\ValidationErrorResponseBuilder;
 use JMP\Utils\PermissionLevel;
 
+/** @var $app Slim\App */
+
 // API Routes - version 1
 $app->group('/v1', function () {
-
+    /** @var $this Slim\App */
     /** @var \Psr\Container\ContainerInterface $container */
+    /** @var $jwtMiddleware \Tuupola\Middleware\JwtAuthentication */
+
     $container = $this->getContainer();
     $jwtMiddleware = $container['jwt'];
 

--- a/api/src/validation.php
+++ b/api/src/validation.php
@@ -2,6 +2,7 @@
 
 use Respect\Validation\Validator as v;
 
+/** @var $container \Psr\Container\ContainerInterface */
 $container = $app->getContainer();
 
 $container['validation'] = function () {

--- a/api/src/validation.php
+++ b/api/src/validation.php
@@ -24,6 +24,7 @@ $container['validation'] = function () {
             'eventType' => v::optional(v::noWhitespace()->numeric()->min(0)),
             'limit' => v::optional(v::noWhitespace()->numeric()->min(0)),
             'offset' => v::optional(v::noWhitespace()->numeric()->min(0)),
+            'all' => v::optional(v::boolVal()),
         ],
         'getEventById' => [
             'id' => v::notEmpty()->noWhitespace()->numeric()

--- a/api/src/validation.php
+++ b/api/src/validation.php
@@ -25,6 +25,7 @@ $container['validation'] = function () {
             'limit' => v::optional(v::noWhitespace()->numeric()->min(0)),
             'offset' => v::optional(v::noWhitespace()->numeric()->min(0)),
             'all' => v::optional(v::boolVal()),
+            'elapsed' => v::optional(v::boolVal()),
         ],
         'getEventById' => [
             'id' => v::notEmpty()->noWhitespace()->numeric()

--- a/docker/db/02_createUser.sh
+++ b/docker/db/02_createUser.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "DROP USER IF EXISTS '${DB_USERNAME}'@'%';";
 mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "CREATE USER '${DB_USERNAME}'@'%';";
 mysql -u root -p"${MYSQL_ROOT_PASSWORD}" -e "GRANT SELECT, INSERT, UPDATE, DELETE ON ${DB_DATABASE}.* TO '${DB_USERNAME}'@'%' IDENTIFIED BY '${DB_PASSWORD}';";

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -406,7 +406,7 @@ Example request:
 GET /v1/events?limit=5&offset=10&eventType=1&all=1
 ```
 Access rights: authentication required  
-**Note:** ```all``` is only considered if the user is an admin
+**Note:** ```all``` is only considered if the user is an admin. Otherwise an 401 is returned.
 
 Returns: List of queried events of all groups in which the user has a membership, sorted __ascending__ by their __start date__ (The near-time events are listed first).
 

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -398,17 +398,19 @@ Parameters:
 | eventType | To get all events by type id         |          |
 | limit     | Limit the amount of events retrieved |          |
 | offset    | Skip the fist _x_ events             |          |
-| all       | List all events **(works only as admin)**|          |
+| all       | List events of all users/groups **(works only as admin)**|          |
+| elapsed   | List also elapsed events             |          |
 
 Example request:
 
 ```http
-GET /v1/events?limit=5&offset=10&eventType=1&all=1
+GET /v1/events?limit=5&offset=10&eventType=1&all=1&elapsed=1
 ```
 Access rights: authentication required  
 **Note:** ```all``` is only considered if the user is an admin. Otherwise an 401 is returned.
 
-Returns: List of queried events of all groups in which the user has a membership, sorted __ascending__ by their __start date__ (The near-time events are listed first).
+Returns: List of queried events of all groups in which the user has a membership, sorted __ascending__ by their __start date__ (The near-time events are listed first).  
+By default (without the elapsed parameter set), only current and upcoming events are selected.
 
 ### Get Event
 

--- a/docs/api-v1.md
+++ b/docs/api-v1.md
@@ -394,19 +394,21 @@ Parameters:
 
 | Field     | Description                          | Required |
 | --------- | ------------------------------------ | -------- |
-| group     | To get all events by the group id    | ❌        |
-| eventType | To get all events by type id         | ❌        |
-| limit     | Limit the amount of events retrieved | ❌        |
-| offset    | Skip the fist _x_ events             | ❌        |
+| group     | To get all events by the group id    |          |
+| eventType | To get all events by type id         |          |
+| limit     | Limit the amount of events retrieved |          |
+| offset    | Skip the fist _x_ events             |          |
+| all       | List all events **(works only as admin)**|          |
 
 Example request:
 
 ```http
-GET /v1/events?limit=5&offset=10&eventType=1
+GET /v1/events?limit=5&offset=10&eventType=1&all=1
 ```
-Access rights: authentication required
+Access rights: authentication required  
+**Note:** ```all``` is only considered if the user is an admin
 
-Returns: List of queried events, sorted __ascending__ by their __start date__ (The near-time events are listed first).
+Returns: List of queried events of all groups in which the user has a membership, sorted __ascending__ by their __start date__ (The near-time events are listed first).
 
 ### Get Event
 

--- a/vue/src/locales/de.json
+++ b/vue/src/locales/de.json
@@ -24,6 +24,7 @@
   "event.fromTo": "Von - Bis:",
   "event.place": "Ort:",
   "event.groups": "Gruppen:",
+  "event.overview.showAll": "Events von allen Gruppen anzeigen",
   "registration.reason": "Grund",
   "registration.reasonRequired": "Grund ist ein Pflichtfeld",
   "registration.reasonPlaceholder": "Grund eingeben",

--- a/vue/src/locales/en.json
+++ b/vue/src/locales/en.json
@@ -24,6 +24,7 @@
   "event.fromTo": "From - To:",
   "event.place": "Place:",
   "event.groups": "Groups:",
+  "event.overview.showAll": "Show events from all groups",
   "registration.reason": "Reason",
   "registration.reasonRequired": "Reason is required",
   "registration.reasonPlaceholder": "Enter reason",

--- a/vue/src/services/event.service.js
+++ b/vue/src/services/event.service.js
@@ -8,20 +8,28 @@ export const eventService = {
 };
 
 function getAll() {
-    return Vue.axios.get('/events')
+    return Vue.axios.get('/events?all=1')
         .then(response => {
             return response.data.json();
         });
 }
 
-function getInitialOverview() {
-    return Vue.axios.get('/events?limit=5').then(response => {
+function getInitialOverview(showAll) {
+    let url = '/events?limit=5';
+    if (showAll) {
+        url += '&all=1';
+    }
+    return Vue.axios.get(url).then(response => {
         return response.data;
     });
 }
 
-function getNextEvents(offset) {
-    return Vue.axios.get(`/events?limit=5&offset=${offset}`).then(response => {
+function getNextEvents(offset, showAll) {
+    let url = `/events?limit=5&offset=${offset}`;
+    if (showAll) {
+        url += '&all=1';
+    }
+    return Vue.axios.get(url).then(response => {
         return response.data;
     });
 }

--- a/vue/src/store/event.module.js
+++ b/vue/src/store/event.module.js
@@ -17,19 +17,19 @@ export const events = {
                     error => commit('getAllFailure', error)
                 );
         },
-        getInitialOverview({commit}) {
+        getInitialOverview({commit}, {showAll}) {
             commit('getInitialOverviewRequest');
 
-            eventService.getInitialOverview()
+            eventService.getInitialOverview(showAll)
                 .then(
                     events => commit('getInitialOverviewSuccess', events),
                     error => commit('getInitialOverviewFailure', error)
                 );
         },
-        getNextEvents({commit}, {offset}) {
+        getNextEvents({commit}, {offset, showAll}) {
             commit('getNextEventsRequest');
 
-            eventService.getNextEvents(offset)
+            eventService.getNextEvents(offset, showAll)
                 .then(
                     events => commit('getNextEventsSuccess', events),
                     error => commit('getNextEventsFailure', error)

--- a/vue/src/views/group/GroupCreate.vue
+++ b/vue/src/views/group/GroupCreate.vue
@@ -46,6 +46,6 @@
                     this.$router.push({ name: 'groups' });
                 }
             });
-        },
+        }
     };
 </script>


### PR DESCRIPTION
New:
- By default, only events of groups in which the user is a member are shown.
- The admin has the possibility to select all events with the new parameter `all`.
    - If a non-admin uses this parameter, a 403 is returned.
- By default, only current and upcoming events are shown.
- It's possible to select elapsed events with the new parameter `elapsed`.
- The events are sorted by the start and then by the end.